### PR TITLE
Rename DRONE_REPO_OWNER to DRONE_REPO_NAMESPACE

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -51,13 +51,14 @@ Following metadata object is available and pre-populated with current build info
 ```go
 {
   Repo {
-    Avatar  string "repository avatar [$DRONE_REPO_AVATAR]"
-    Branch  string "repository default branch [$DRONE_REPO_BRANCH]"
-    Link    string "repository link [$DRONE_REPO_LINK]"
-    Name    string "repository name [$DRONE_REPO_NAME]"
-    Owner   string "repository owner [$DRONE_REPO_OWNER]"
-    Private bool   "repository is private [$DRONE_REPO_PRIVATE]"
-    Trusted bool   "repository is trusted [$DRONE_REPO_TRUSTED]"
+    Avatar    string "repository avatar [$DRONE_REPO_AVATAR]"
+    Branch    string "repository default branch [$DRONE_REPO_BRANCH]"
+    Link      string "repository link [$DRONE_REPO_LINK]"
+    Name      string "repository name [$DRONE_REPO_NAME]"
+    Owner     string "repository owner [$DRONE_REPO_NAMESPACE]"
+    Namespace string "repository namespace [$DRONE_REPO_NAMESPACE]"
+    Private   bool   "repository is private [$DRONE_REPO_PRIVATE]"
+    Trusted   bool   "repository is trusted [$DRONE_REPO_TRUSTED]"
   }
 
   Build {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-
 # drone-cache
+
 [![semver](https://img.shields.io/badge/semver-1.0.2-blue.svg?cacheSeconds=2592000)](https://github.com/meltwater/drone-cache/releases) [![Maintenance](https://img.shields.io/maintenance/yes/2019.svg)](https://github.com/meltwater/drone-cache/commits/master) [![Drone](https://cloud.drone.io/api/badges/meltwater/drone-cache/status.svg)](https://cloud.drone.io/meltwater/drone-cache) [![Go Doc](https://godoc.org/github.com/meltwater/drone-cache?status.svg)](http://godoc.org/github.com/meltwater/drone-cache) [![Go Report Card](https://goreportcard.com/badge/github.com/meltwater/drone-cache)](https://goreportcard.com/report/github.com/meltwater/drone-cache) [![](https://images.microbadger.com/badges/image/meltwater/drone-cache.svg)](https://microbadger.com/images/meltwater/drone-cache) [![](https://images.microbadger.com/badges/version/meltwater/drone-cache.svg)](https://microbadger.com/images/meltwater/drone-cache)
 
 <p align="center"><img src="images/drone_gopher.png" width="400"></p>
@@ -26,7 +26,7 @@ With restored dependencies from a cache, commands like `mix deps.get` will only 
 
 ## Example Usage of drone-cache
 
-The following `.drone.yml` configuration show the most common use of drone-cache. 
+The following `.drone.yml` configuration show the most common use of drone-cache.
 
 Note: These configs use drone 1.0 syntax. If you are using drone 0.8, check the examples in [docs/examples/drone-0.8.md](docs/examples/drone-0.8.md).
 
@@ -80,8 +80,8 @@ steps:
 
 ### Other Examples
 
-* examples for Drone 0.8, see [docs/examples/drone-0.8.md](docs/examples/drone-0.8.md)
-* examples for Drone 1.0, see [docs/examples/drone-1.0.md](docs/examples/drone-1.0.md)
+- examples for Drone 0.8, see [docs/examples/drone-0.8.md](docs/examples/drone-0.8.md)
+- examples for Drone 1.0, see [docs/examples/drone-1.0.md](docs/examples/drone-1.0.md)
 
 ## Usage
 
@@ -102,7 +102,8 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --repo.fullname value, --rf value           repository full name [$DRONE_REPO]
-   --repo.namespace value, --ro value          repository namespace [$DRONE_REPO_NAMESPACE]
+   --repo.namespace value, --rns value         repository namespace [$DRONE_REPO_NAMESPACE]
+   --repo.owner value, --ro value              repository owner [$DRONE_REPO_OWNER]
    --repo.name value, --rn value               repository name [$DRONE_REPO_NAME]
    --repo.link value, --rl value               repository link [$DRONE_REPO_LINK]
    --repo.avatar value, --ra value             repository avatar [$DRONE_REPO_AVATAR]
@@ -211,13 +212,13 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 
 ## Future work
 
-* [ ] Add s/FTP Backend
-* [ ] Fix goreleaser/drone/docker conflicts or remove redundancy with Drone jsonnet
-* [ ] Add cache key fallback list
-* [ ] Flush or TTL/Retention policy
-* [ ] Add Google Cloud Storage Backend
-* [ ] Add Microsoft Azure Storage Backend
-* [ ] Add unit tests
+- [ ] Add s/FTP Backend
+- [ ] Fix goreleaser/drone/docker conflicts or remove redundancy with Drone jsonnet
+- [ ] Add cache key fallback list
+- [ ] Flush or TTL/Retention policy
+- [ ] Add Google Cloud Storage Backend
+- [ ] Add Microsoft Azure Storage Backend
+- [ ] Add unit tests
 
 ## Versioning
 
@@ -225,18 +226,17 @@ We use [SemVer](http://semver.org/) for versioning. For the versions available, 
 
 ## Authors and Acknowledgement
 
-* [@dim](https://github.com/dim) - Thanks for [original work](https://github.com/bsm/drone-s3-cache)!
-* [@kakkoyun](https://github.com/kakkoyun)
-* [@salimane](https://github.com/salimane)
-* [@AdamGlazerMW](https://github.com/AdamGlazerMW) - Special thanks to Adam for the amazing artwork!
+- [@dim](https://github.com/dim) - Thanks for [original work](https://github.com/bsm/drone-s3-cache)!
+- [@kakkoyun](https://github.com/kakkoyun)
+- [@salimane](https://github.com/salimane)
+- [@AdamGlazerMW](https://github.com/AdamGlazerMW) - Special thanks to Adam for the amazing artwork!
 
 Also see the list of [all contributors](https://github.com/meltwater/drone-cache/graphs/contributors).
 
-
 ### Inspiration
 
-* https://github.com/bsm/drone-s3-cache (original work)
-* https://github.com/Drillster/drone-volume-cache
+- https://github.com/bsm/drone-s3-cache (original work)
+- https://github.com/Drillster/drone-volume-cache
 
 ## License and Copyright
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --repo.fullname value, --rf value           repository full name [$DRONE_REPO]
-   --repo.owner value, --ro value              repository owner [$DRONE_REPO_OWNER]
+   --repo.namespace value, --ro value          repository namespace [$DRONE_REPO_NAMESPACE]
    --repo.name value, --rn value               repository name [$DRONE_REPO_NAME]
    --repo.link value, --rl value               repository link [$DRONE_REPO_LINK]
    --repo.avatar value, --ra value             repository avatar [$DRONE_REPO_AVATAR]

--- a/docs/cache_key_templates.md
+++ b/docs/cache_key_templates.md
@@ -27,8 +27,8 @@ Following metadata object is available and pre-populated with current build info
     Avatar  string "repository avatar [$DRONE_REPO_AVATAR]"
     Branch  string "repository default branch [$DRONE_REPO_BRANCH]"
     Link    string "repository link [$DRONE_REPO_LINK]"
-    Name    string "repository name [$DRONE_REPO_NAME]"
-    Owner   string "repository owner [$DRONE_REPO_OWNER]"
+    Name    string "repository name [$DRONE_REPO_NAMESPACE]"
+    Namespace   string "repository namespace [$DRONE_REPO_NAMESPACE]"
     Private bool   "repository is private [$DRONE_REPO_PRIVATE]"
     Trusted bool   "repository is trusted [$DRONE_REPO_TRUSTED]"
   }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ func main() {
 	app.Name = "Drone cache plugin"
 	app.Usage = "Drone cache plugin"
 	app.Action = run
-	app.Version = "1.0.2"
+	app.Version = "1.0.3"
 	app.Flags = []cli.Flag{
 		// Repo args
 
@@ -26,9 +26,9 @@ func main() {
 			EnvVar: "DRONE_REPO",
 		},
 		cli.StringFlag{
-			Name:   "repo.owner, ro",
-			Usage:  "repository owner",
-			EnvVar: "DRONE_REPO_OWNER",
+			Name:   "repo.namespace, rns",
+			Usage:  "repository namespace",
+			EnvVar: "DRONE_REPO_NAMESPACE",
 		},
 		cli.StringFlag{
 			Name:   "repo.name, rn",
@@ -288,13 +288,14 @@ func run(c *cli.Context) error {
 	plg := plugin.Plugin{
 		Metadata: metadata.Metadata{
 			Repo: metadata.Repo{
-				Owner:   c.String("repo.owner"),
-				Name:    c.String("repo.name"),
-				Link:    c.String("repo.link"),
-				Avatar:  c.String("repo.avatar"),
-				Branch:  c.String("repo.branch"),
-				Private: c.Bool("repo.private"),
-				Trusted: c.Bool("repo.trusted"),
+				Namespace: c.String("repo.namespace"),
+				Owner:     c.String("repo.namespace"),
+				Name:      c.String("repo.name"),
+				Link:      c.String("repo.link"),
+				Avatar:    c.String("repo.avatar"),
+				Branch:    c.String("repo.branch"),
+				Private:   c.Bool("repo.private"),
+				Trusted:   c.Bool("repo.trusted"),
 			},
 			Build: metadata.Build{
 				Number:   c.Int("build.number"),

--- a/main.go
+++ b/main.go
@@ -31,6 +31,11 @@ func main() {
 			EnvVar: "DRONE_REPO_NAMESPACE",
 		},
 		cli.StringFlag{
+			Name:   "repo.owner, owner",
+			Usage:  "repository owner (for Drone version < 1.0)",
+			EnvVar: "DRONE_REPO_OWNER",
+		},
+		cli.StringFlag{
 			Name:   "repo.name, rn",
 			Usage:  "repository name",
 			EnvVar: "DRONE_REPO_NAME",
@@ -289,7 +294,7 @@ func run(c *cli.Context) error {
 		Metadata: metadata.Metadata{
 			Repo: metadata.Repo{
 				Namespace: c.String("repo.namespace"),
-				Owner:     c.String("repo.namespace"),
+				Owner:     c.String("repo.owner"),
 				Name:      c.String("repo.name"),
 				Link:      c.String("repo.link"),
 				Avatar:    c.String("repo.avatar"),

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -7,8 +7,8 @@ type (
 		Branch    string
 		Link      string
 		Name      string
-		Namespace string
-		Owner     string
+		Namespace string // used by Drone versions >= 1.0
+		Owner     string // used by Drone versions < 1.0
 		Private   bool
 		Trusted   bool
 	}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -3,13 +3,14 @@ package metadata
 type (
 	// Repo stores information about repository that is built
 	Repo struct {
-		Avatar  string
-		Branch  string
-		Link    string
-		Name    string
-		Owner   string
-		Private bool
-		Trusted bool
+		Avatar    string
+		Branch    string
+		Link      string
+		Name      string
+		Namespace string
+		Owner     string
+		Private   bool
+		Trusted   bool
 	}
 
 	// Build stores information about current build


### PR DESCRIPTION
It appears that `$DRONE_REPO_OWNER` has been renamed to `$DRONE_REPO_NAMESPACE`: https://docs.drone.io/reference/environ/drone-repo-namespace/

This PR removes the CLI flag `--repo.owner` and replaces it with `--repo.namespace`, and adds a `Namespace` field to the `Repo` definition. It preserves the `Owner` field for backwards-compatibility, which is filled out using the value from `$DRONE_REPO_NAMESPACE` / `--repo.namespace`. 