### PR TITLE
Update guidelines and Stop pushing docker images with latest tag when master merge happens

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -126,7 +126,7 @@ steps:
     event:
     - push
 
-- name: release-docker-latest
+- name: release-docker-dev
   image: plugins/docker
   settings:
     build_args_from_env:
@@ -143,7 +143,7 @@ steps:
     password:
       from_secret: docker_password
     repo: meltwater/drone-cache
-    tags: latest
+    tags: dev
     username:
       from_secret: docker_username
   when:
@@ -287,6 +287,32 @@ steps:
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
+
+- name: release-docker-latest
+  image: plugins/docker
+  settings:
+    build_args_from_env:
+    - BUILD_DATE
+    - DOCKERFILE_PATH
+    - VCS_REF
+    - VERSION
+    dockerfile: docker/Dockerfile.linux.386
+    environment:
+    - "BUILD_DATE=$(date -u +\"%Y-%m-%dT%H:%M:%S%Z\")"
+    - "DOCKERFILE_PATH=\"/docker/Dockerfile.linux.386\""
+    - VCS_REF=$(git rev-parse --short HEAD)
+    - VERSION=$(git describe --always --tags --dirty)
+    password:
+      from_secret: docker_password
+    repo: meltwater/drone-cache
+    tags: latest
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - master
+    event:
+    - push
 
 - name: release-docker
   image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -117,6 +117,7 @@ steps:
   commands:
   - apk add --update make upx
   - goreleaser release --rm-dist --snapshot
+  - echo "$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short HEAD)" > .tags
   environment:
     GITHUB_TOKEN:
       from_secret: github_token
@@ -126,7 +127,7 @@ steps:
     event:
     - push
 
-- name: release-docker-dev
+- name: release-docker-vsc-ref
   image: plugins/docker
   settings:
     build_args_from_env:
@@ -143,7 +144,7 @@ steps:
     password:
       from_secret: docker_password
     repo: meltwater/drone-cache
-    tags: dev
+    # tags: this releases with tags in .tags
     username:
       from_secret: docker_username
   when:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,11 +36,11 @@ Fixes #
 - [ ] Read the **CONTRIBUTING** document.
 - [ ] Read the **CODE OF CONDUCT** document.
 - [ ] Add tests to cover changes.
-- [ ] Make sure your code follows the code style of this project
-- [ ] Make sure CI and all other PR checks are green OR
+- [ ] Ensure your code follows the code style of this project.
+- [ ] Ensure CI and all other PR checks are green OR
     - [ ] Code compiles correctly.
     - [ ] Created tests which fail without the change (if possible).
     - [ ] All new and existing tests passed.
-- [ ] Add your changes to [CHANGELOG](CHANGELOG.md).
+- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
 - [ ] Improve and update the [README](README.md) (if necessary).
-- [ ] Make sure [documentation](./DOCS.md) is up-to-date. Same file should also be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) by sending a PR to that repository.
+- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,8 +33,8 @@ Fixes #
 
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
-- [ ] Read the **CONTRIBUTING** document.
-- [ ] Read the **CODE OF CONDUCT** document.
+- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
+- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
 - [ ] Add tests to cover changes.
 - [ ] Ensure your code follows the code style of this project.
 - [ ] Ensure CI and all other PR checks are green OR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,12 +6,13 @@
 Thank you for your pull request. Please provide a description above and review
 the requirements below.
 
-Bug fixes and new features should include tests.
+**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**
 
 Contributors guide: ./CONTRIBUTING.md
+Code of conduct: ./CODE_OF_CONDUCT.md
 -->
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.
 
 Fixes #
 
@@ -33,18 +34,13 @@ Fixes #
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] Read the **CONTRIBUTING** document.
-- [ ] Add tests to cover my changes.
+- [ ] Read the **CODE OF CONDUCT** document.
+- [ ] Add tests to cover changes.
 - [ ] Make sure your code follows the code style of this project
 - [ ] Make sure CI and all other PR checks are green OR
-    - [ ] Code compiles correctly/
-    - [ ] Created tests which fail without the change (if possible)/
+    - [ ] Code compiles correctly.
+    - [ ] Created tests which fail without the change (if possible).
     - [ ] All new and existing tests passed.
-- [ ] Extended and update the README (if necessary).
+- [ ] Add your changes to [CHANGELOG](CHANGELOG.md).
+- [ ] Improve and update the [README](README.md) (if necessary).
 - [ ] Make sure [documentation](./DOCS.md) is up-to-date. Same file should also be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) by sending a PR to that repository.
-
-**PLEASE DO NOT INTRODUCE BREAKING CHANGES**
-
-**Keep in mind that users usually use the `latest` tagged images in their pipeline, please make sure you do not interfere with their working workflow.**
-
-- [ ] Version bump if you have to, update version in documentation (fix or feature that would cause existing functionality to change).
-    - We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/meltwater/drone-cache/tags).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Ureleased
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing
+
+### Removed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
 ## [1.0.4] - 2019-06-14
 
 ### Added
@@ -72,14 +90,14 @@ f20a2ea Rename DRONE_REPO_OWNER to DRONE_REPO_NAMESPACE
 
 ### Changed
 
-dd4c02b Do not try to rebuild cache for the paths do not exist
-48d7eeb Fix drone release
-8eb3a08 Fix image name in README
-d83dea6 Fix link to examples in README
-262bf0e Fix parameter naming issue in examples
-17e23dc Fix pure Docker example in Readme
-4843910 Some README improvements
-8ad9b08 goreleaser releases Docker
+- Do not try to rebuild cache for the paths do not exist
+- Fix drone release
+- Fix image name in README
+- Fix link to examples in README
+- Fix parameter naming issue in examples
+- Fix pure Docker example in Readme
+- Some README improvements
+- goreleaser releases Docker
 
 ### Removed
 
@@ -159,7 +177,7 @@ ba005b6 Improve README
 
 ### Changed
 
-3ffa242 Improve Documentation
+- Improve Documentation
 
 ### Removed
 
@@ -181,8 +199,8 @@ ba005b6 Improve README
 
 ### Changed
 
-51a7b44 Enable more linters and fix discovered issues (#14)
-b9f8e82 Update documentation (#16)
+- Enable more linters and fix discovered issues (#14)
+- Update documentation (#16)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ f20a2ea Rename DRONE_REPO_OWNER to DRONE_REPO_NAMESPACE
 - Fix image name in README
 - Fix link to examples in README
 - Fix parameter naming issue in examples
-- Fix pure Docker example in Readme
+- Fix pure Docker example in README
 - Some README improvements
 - goreleaser releases Docker
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,8 @@ the requirements below.
 0. Check out [Pull Request Checklist](#pull-request-checklist), ensure you have fulfilled each step.
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a
    build.
-2. Please ensure the [README](README.md) and [DOCS](./DOCS.md) are up-to-date with details of changes to the interface, this includes new environment.
-   variables, exposed ports, useful file locations and container parameters.
+2. Please ensure the [README](README.md) and [DOCS](./DOCS.md) are up-to-date with details of changes to the command-line interface,
+    this includes new environment variables, exposed ports, useful file locations and container parameters.
 3. **PLEASE ENSURE YOU DO NOT INTRODUCE BREAKING CHANGES.**
 4. **PLEASE ENSURE BUG FIXES AND NEW FEATURES INCLUDE TESTS.**
 5. You may merge the Pull Request in once you have the sign-off of one other maintainer/code owner,
@@ -26,17 +26,17 @@ the requirements below.
 
 ## Pull Request Checklist
 
-- [x] Read the **CONTRIBUTING** document. (It's checked since you are alread here.)
+- [x] Read the **CONTRIBUTING** document. (It's checked since you are already here.)
 - [ ] Read the **CODE OF CONDUCT** document.
 - [ ] Add tests to cover changes.
-- [ ] Make sure your code follows the code style of this project
-- [ ] Make sure CI and all other PR checks are green OR
+- [ ] Ensure your code follows the code style of this project.
+- [ ] Ensure CI and all other PR checks are green OR
     - [ ] Code compiles correctly.
     - [ ] Created tests which fail without the change (if possible).
     - [ ] All new and existing tests passed.
-- [ ] Add your changes to [CHANGELOG](CHANGELOG.md).
+- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
 - [ ] Improve and update the [README](README.md) (if necessary).
-- [ ] Make sure [documentation](./DOCS.md) is up-to-date. Same file should also be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) by sending a PR to that repository.
+- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
 
 ## Release Process
 
@@ -46,8 +46,9 @@ the requirements below.
 1. Increase the version numbers in any examples files and the README.md to the new version that this
    release would represent. The versioning scheme we use is [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/meltwater/drone-cache/tags).
 
-2. Make sure [CHANGELOG](CHANGELOG.md) is up-to-date.
-3. Create a tag on master. Any changes on master will trigger a release with given tag and `latest tag.
+2. Ensure [CHANGELOG](CHANGELOG.md) is up-to-date with new version changes.
+3. Update version references.
+4. Create a tag on master. Any changes on master will trigger a release with given tag and `latest tag.
 
     ```console
     $ git tag -am 'vX.X.X'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ the requirements below.
 ## Pull Request Checklist
 
 - [x] Read the **CONTRIBUTING** document. (It's checked since you are already here.)
-- [ ] Read the **CODE OF CONDUCT** document.
+- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
 - [ ] Add tests to cover changes.
 - [ ] Ensure your code follows the code style of this project.
 - [ ] Ensure CI and all other PR checks are green OR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,55 @@ email, or any other method with the owners of this repository before making a ch
 
 Please note we have a [code of conduct](CODE_OF_CONDUCT.md) that we ask you to follow in all your interactions with the project.
 
+**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
+
+*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
+
+Thank you for your pull request. Please provide a description above and review
+the requirements below.
+
 ## Pull Request Process
 
+0. Check out [Pull Request Checklist](#pull-request-checklist), ensure you have fulfilled each step.
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a
    build.
-2. Update the README.md with details of changes to the interface, this includes new environment
+2. Please ensure the [README](README.md) and [DOCS](./DOCS.md) are up-to-date with details of changes to the interface, this includes new environment.
    variables, exposed ports, useful file locations and container parameters.
-3. Increase the version numbers in any examples files and the README.md to the new version that this
-   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
-4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
-   do not have permission to do that, you may request the second reviewer to merge it for you.
+3. **PLEASE ENSURE YOU DO NOT INTRODUCE BREAKING CHANGES.**
+4. **PLEASE ENSURE BUG FIXES AND NEW FEATURES INCLUDE TESTS.**
+5. You may merge the Pull Request in once you have the sign-off of one other maintainer/code owner,
+   or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Pull Request Checklist
+
+- [x] Read the **CONTRIBUTING** document. (It's checked since you are alread here.)
+- [ ] Read the **CODE OF CONDUCT** document.
+- [ ] Add tests to cover changes.
+- [ ] Make sure your code follows the code style of this project
+- [ ] Make sure CI and all other PR checks are green OR
+    - [ ] Code compiles correctly.
+    - [ ] Created tests which fail without the change (if possible).
+    - [ ] All new and existing tests passed.
+- [ ] Add your changes to [CHANGELOG](CHANGELOG.md).
+- [ ] Improve and update the [README](README.md) (if necessary).
+- [ ] Make sure [documentation](./DOCS.md) is up-to-date. Same file should also be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) by sending a PR to that repository.
+
+## Release Process
+
+*Only concerns maintainers/code owners*
+
+0. **PLEASE DO NOT INTRODUCE BREAKING CHANGES**
+1. Increase the version numbers in any examples files and the README.md to the new version that this
+   release would represent. The versioning scheme we use is [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/meltwater/drone-cache/tags).
+
+2. Make sure [CHANGELOG](CHANGELOG.md) is up-to-date.
+3. Create a tag on master. Any changes on master will trigger a release with given tag and `latest tag.
+
+    ```console
+    $ git tag -am 'vX.X.X'
+    > ...
+    $ git push --tags
+    > ...
+    ```
+
+> **Keep in mind that users usually use the `latest` tagged images in their pipeline, please make sure you do not interfere with their working workflow.**


### PR DESCRIPTION
Fixes #69 

## Proposed Changes
- Removes `release-latest` stage from CI's master merge pipeline.
- Updates and improves contributing guidelines.

### Description
This PR introduces changes to ensure backwards compatibility and guarantee not to introduce breaking changes prevent auto releasing of `latest` tag when a merge happens on `master`. Since `latest` is used default image for most of the pipelines.

### Checklist
- [X] Read the **CONTRIBUTING** document.
- [ ] Add tests to cover my changes.
- [X] Make sure your code follows the code style of this project
- [X] Make sure CI and all other PR checks are green OR
    - [x] Code compiles correctly/
    - [x] Created tests which fail without the change (if possible)/
    - [x] All new and existing tests passed.
- [x] Extended and update the README (if necessary).
- [x] Make sure [documentation](./DOCS.md) is up-to-date. Same file should also be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) by sending a PR to that repository.
