### PR TITLE
Fix relative path resolving to not trim dot char

### DIFF
--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -122,7 +122,9 @@ func relative(parent string, path string) (string, error) {
 	}
 
 	// NOTICE: filepath.Rel puts "../" when given path is not under parent.
-	rel = strings.TrimLeft(rel, "../")
+	for strings.HasPrefix(rel, "../") {
+		rel = strings.TrimPrefix(rel, "../")
+	}
 	rel = filepath.ToSlash(rel)
 	return strings.TrimPrefix(filepath.Join(rel, name), "/"), nil
 }

--- a/archive/tar/tar_test.go
+++ b/archive/tar/tar_test.go
@@ -125,6 +125,11 @@ func TestExtract(t *testing.T) {
 	_, err = create(ta, filesWithSymlink, archiveWithSymlinkPath)
 	test.Ok(t, err)
 
+	filesWithSymlinkHidden := exampleFileTreeWithSymlinks(t, ".tar_extract_symlink")
+	archiveWithSymlinkHiddenPath := filepath.Join(arcDir, "test_with_symlink_hidden.tar")
+	_, err = create(ta, filesWithSymlinkHidden, archiveWithSymlinkHiddenPath)
+	test.Ok(t, err)
+
 	emptyArchivePath := filepath.Join(arcDir, "empty_test.tar")
 	_, err = create(ta, []string{}, emptyArchivePath)
 	test.Ok(t, err)
@@ -193,6 +198,14 @@ func TestExtract(t *testing.T) {
 			ta:          New(log.NewNopLogger(), testRootMounted, false),
 			archivePath: archiveWithSymlinkPath,
 			srcs:        filesWithSymlink,
+			written:     43,
+			err:         nil,
+		},
+		{
+			name:        "existing archive with hidden symbolic links",
+			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			archivePath: archiveWithSymlinkHiddenPath,
+			srcs:        filesWithSymlinkHidden,
 			written:     43,
 			err:         nil,
 		},


### PR DESCRIPTION
### Description

Current code while cleaning up path would trim `.` (dot) character. 

Fixes #105

### Checklist

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [x] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] Created tests which fail without the change (if possible).
    - [x] All new and existing tests passed.
