### PR TITLE
Update aws-sdk-go to v1.23.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#115](https://github.com/meltwater/drone-cache/pull/102) Update aws-sdk-go to add support for IAM Roles for Service Accounts in Kubernetes.
 - [#102](https://github.com/meltwater/drone-cache/pull/102) Implement option to disable cache rebuild if it already exists in storage.
 - [#86](https://github.com/meltwater/drone-cache/pull/86) Add backend operation timeout option that cancels request if they take longer than given duration. `BACKEND_OPERATION_TIMEOUT`, `backend.operation-timeot`. Default value is `3 minutes`.
 - [#86](https://github.com/meltwater/drone-cache/pull/86) Customize the cache key in the path. Adds a new `remote_root` option to customize it. Defaults to `repo.name`.

--- a/DOCS.md
+++ b/DOCS.md
@@ -102,6 +102,8 @@ steps:
   - name: restore-cache
     image: meltwater/drone-cache:dev
     environment:
+      # leaving these variables unset will default to using instance profile credentials
+      # when running in EC2 or IAM Roles for Service Accounts, if configured, in Kubernetes
       AWS_ACCESS_KEY_ID:
         from_secret: aws_access_key_id
       AWS_SECRET_ACCESS_KEY:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ steps:
     image: meltwater/drone-cache
     environment:
       # leaving these variables unset will default to using instance profile credentials
-      # when running in EC2 or IAM Roles for Service Accounts, if configured, in EKS
+      # when running in EC2 or IAM Roles for Service Accounts, if configured, in Kubernetes
       AWS_ACCESS_KEY_ID:
         from_secret: aws_access_key_id
       AWS_SECRET_ACCESS_KEY:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ steps:
   - name: restore-cache
     image: meltwater/drone-cache
     environment:
+      # leaving these variables unset will default to using instance profile credentials
+      # when running in EC2 or IAM Roles for Service Accounts, if configured, in EKS
       AWS_ACCESS_KEY_ID:
         from_secret: aws_access_key_id
       AWS_SECRET_ACCESS_KEY:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	cloud.google.com/go/storage v1.1.0
 	github.com/Azure/azure-storage-blob-go v0.8.0
 	github.com/Azure/go-autorest/autorest/adal v0.8.1 // indirect
-	github.com/aws/aws-sdk-go v1.16.35
+	github.com/aws/aws-sdk-go v1.23.13
 	github.com/campoy/embedmd v1.0.0
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-kit/kit v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -44,10 +44,8 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrU
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/aws/aws-sdk-go v1.16.35 h1:qz1h7uxswkVaE6kJPoPWwt3F76HlCLrg/UyDJq3cavc=
-github.com/aws/aws-sdk-go v1.16.35 h1:qz1h7uxswkVaE6kJPoPWwt3F76HlCLrg/UyDJq3cavc=
-github.com/aws/aws-sdk-go v1.16.35/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.16.35/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.13 h1:l/NG+mgQFRGG3dsFzEj0jw9JIs/zYdtU6MXhY1WIDmM=
+github.com/aws/aws-sdk-go v1.23.13/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bombsimon/wsl/v2 v2.0.0 h1:+Vjcn+/T5lSrO8Bjzhk4v14Un/2UyCA1E3V5j9nwTkQ=


### PR DESCRIPTION
Updates go.mod to use a more recent version of aws-sdk-go, specifically one which is recommended for supporting [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) (IRSA) when running in Kubernetes.

Fixes #114

## Proposed Changes
- Update go.mod and go.sum to reference the minimum recommended version of aws-sdk-go for IRSA
- Include a note in the README about defaulting to instance profile and IRSA credentials

### Description
Newer versions of the Go AWS SDK include additional methods for automatically obtaining IAM credentials. Specifically, credentials can be obtained using `sts.AssumeRoleWithWebIdentity`, which is a requirement for using IAM Roles for Service Accounts when running in Kubernetes. The AWS documentation [recommends using v1.23.13](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-minimum-sdk.html) or above to use this feature.

Based on the existing S3 client code, using that version of the SDK should be all that's needed to support this feature.

Not sure how to best test this change. The built-in tests pass and I was able to use drone-cache with IRSA credentials using the updated SDK. Mocking out an STS service may prove to be tough. Any input on how to best accomplish this would be welcome. 

### Checklist
- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] ~~Add tests to cover changes.~~
- [x] Ensure your code follows the code style of this project.
- [x] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [ ] ~~Created tests which fail without the change (if possible).~~
    - [x] All new and existing tests passed.
- [x] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
- [x] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
