### PR TITLE
Fix NoCredentialProviders error when accessing public bucket on Minio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fixed Anonymous Credentials Error on public buckets
+  - Fixes [#132](https://github.com/meltwater/drone-cache/issues/132)
+
 ### Added
 
 - [#102](https://github.com/meltwater/drone-cache/pull/102) Implement option to disable cache rebuild if it already exists in storage.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ USAGE:
    drone-cache [global options] command [command options] [arguments...]
 
 VERSION:
-   v1.1.0-rc0
+   v1.1.0
 
 COMMANDS:
    help, h  Shows a list of commands or help for one command

--- a/storage/backend/s3/s3.go
+++ b/storage/backend/s3/s3.go
@@ -35,6 +35,7 @@ func New(l log.Logger, c Config, debug bool) (*Backend, error) {
 		Endpoint:         &c.Endpoint,
 		DisableSSL:       aws.Bool(!strings.HasPrefix(c.Endpoint, "https://")),
 		S3ForcePathStyle: aws.Bool(c.PathStyle),
+		Credentials:      credentials.AnonymousCredentials,
 	}
 
 	if c.Key != "" && c.Secret != "" {


### PR DESCRIPTION
Fixes [#132](https://github.com/meltwater/drone-cache/issues/132)

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [x] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] Created tests which fail without the change (if possible).
    - [x] All new and existing tests passed.
- [x] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
- [x] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
