### PR TITLE
Fix GCS credentials when no endpoint specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Anonymous Credentials Error on public buckets
   - Fixes [#132](https://github.com/meltwater/drone-cache/issues/132)
+- [#138](https://github.com/meltwater/drone-cache/pull/138) Fix GCS to pass credentials correctly when `GCS_ENDPOINT` is not set.
 
 ### Added
 


### PR DESCRIPTION
### Description

Fixes #137 by not overriding the HTTP client when not necessary.

Without this, GCS errors with 403:

```
<?xml version='1.0' encoding='UTF-8'?><Error><Code>AccessDenied</Code><Message>Access denied.</Message><Details>Anonymous caller does not have storage.objects.get access to the Google Cloud Storage object.</Details></Error>
```

This happens when `GCS_ENDPOINT` isn't set, and the Google SDK is called with `option.WithHTTPClient()` using a custom HTTP client that disables TLS verification. 

### Checklist

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes. [Not possible since this only happens with TLS.]
- [x] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] All new and existing tests passed.
- [x] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
