### PR TITLE
add absolute path mode

### DIFF
--- a/archive/gzip/gzip_test.go
+++ b/archive/gzip/gzip_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-kit/kit/log"
@@ -19,12 +20,21 @@ var (
 	testRoot          = "testdata"
 	testRootMounted   = "testdata/mounted"
 	testRootExtracted = "testdata/extracted"
+	testAbsPattern    = "testdata_absolute"
 )
 
 func TestCreate(t *testing.T) {
 	test.Ok(t, os.MkdirAll(testRootMounted, 0755))
 	test.Ok(t, os.MkdirAll(testRootExtracted, 0755))
-	t.Cleanup(func() { os.RemoveAll(testRoot) })
+
+	testAbs, err := ioutil.TempDir("", testAbsPattern)
+	test.Ok(t, err)
+	test.Equals(t, filepath.IsAbs(testAbs), true)
+
+	t.Cleanup(func() {
+		os.RemoveAll(testRoot)
+		os.RemoveAll(testAbs)
+	})
 
 	for _, tc := range []struct {
 		name    string
@@ -44,7 +54,7 @@ func TestCreate(t *testing.T) {
 			name: "non-existing mount paths",
 			tgz:  New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
 			srcs: []string{
-				"iamnotexists",
+				"idonotexist",
 				"metoo",
 			},
 			written: 0,
@@ -53,7 +63,7 @@ func TestCreate(t *testing.T) {
 		{
 			name:    "existing mount paths",
 			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
-			srcs:    exampleFileTree(t, "gzip_create"),
+			srcs:    exampleFileTree(t, "gzip_create", testRootMounted),
 			written: 43, // 3 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
@@ -71,12 +81,30 @@ func TestCreate(t *testing.T) {
 			written: 43,
 			err:     nil,
 		},
+		{
+			name:    "absolute mount paths",
+			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			srcs:    exampleFileTree(t, "tar_create", testAbs),
+			written: 43,
+			err:     nil,
+		},
 	} {
-		tc := tc // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		tc := tc // NOTICE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			// Setup
+			var absSrcs []string
+			var relativeSrcs []string
+
+			for _, src := range tc.srcs {
+				if strings.HasPrefix(src, "/") {
+					absSrcs = append(absSrcs, src)
+				} else {
+					relativeSrcs = append(relativeSrcs, src)
+				}
+			}
+
 			dstDir, dstDirClean := test.CreateTempDir(t, "gzip_create_archives", testRootMounted)
 			t.Cleanup(dstDirClean)
 
@@ -91,12 +119,21 @@ func TestCreate(t *testing.T) {
 				return
 			}
 
+			// Test
+			for _, src := range absSrcs {
+				test.Ok(t, os.RemoveAll(src))
+			}
+
 			test.Exists(t, archivePath)
 			test.Assert(t, written == tc.written, "case %q: written bytes got %d want %v", tc.name, written, tc.written)
 
 			_, err = extract(tc.tgz, archivePath, extDir)
 			test.Ok(t, err)
-			test.EqualDirs(t, extDir, testRootMounted, tc.srcs)
+			test.EqualDirs(t, extDir, testRootMounted, relativeSrcs)
+
+			for _, src := range absSrcs {
+				test.Exists(t, src)
+			}
 		})
 	}
 }
@@ -104,7 +141,15 @@ func TestCreate(t *testing.T) {
 func TestExtract(t *testing.T) {
 	test.Ok(t, os.MkdirAll(testRootMounted, 0755))
 	test.Ok(t, os.MkdirAll(testRootExtracted, 0755))
-	t.Cleanup(func() { os.RemoveAll(testRoot) })
+
+	testAbs, err := ioutil.TempDir("", testAbsPattern)
+	test.Ok(t, err)
+	test.Equals(t, filepath.IsAbs(testAbs), true)
+
+	t.Cleanup(func() {
+		os.RemoveAll(testRoot)
+		os.RemoveAll(testAbs)
+	})
 
 	// Setup
 	tgz := New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression)
@@ -112,9 +157,9 @@ func TestExtract(t *testing.T) {
 	arcDir, arcDirClean := test.CreateTempDir(t, "gzip_extract_archive")
 	t.Cleanup(arcDirClean)
 
-	files := exampleFileTree(t, "gzip_extract")
+	files := exampleFileTree(t, "gzip_extract", testRootMounted)
 	archivePath := filepath.Join(arcDir, "test.tar.gz")
-	_, err := create(tgz, files, archivePath)
+	_, err = create(tgz, files, archivePath)
 	test.Ok(t, err)
 
 	nestedFiles := exampleNestedFileTree(t, "gzip_extract_nested")
@@ -133,6 +178,11 @@ func TestExtract(t *testing.T) {
 
 	badArchivePath := filepath.Join(arcDir, "bad_test.tar.gz")
 	test.Ok(t, ioutil.WriteFile(badArchivePath, []byte("hello\ndrone\n"), 0644))
+
+	filesAbs := exampleFileTree(t, ".gzip_extract_absolute", testAbs)
+	archiveAbsPath := filepath.Join(arcDir, "test_absolute.tar.gz")
+	_, err = create(tgz, filesAbs, archiveAbsPath)
+	test.Ok(t, err)
 
 	for _, tc := range []struct {
 		name        string
@@ -198,22 +248,49 @@ func TestExtract(t *testing.T) {
 			written:     43,
 			err:         nil,
 		},
+		{
+			name:        "absolute mount paths",
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			archivePath: archiveAbsPath,
+			srcs:        filesAbs,
+			written:     43,
+			err:         nil,
+		},
 	} {
 		tc := tc // NOTE: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Setup
+			var absSrcs []string
+			var relativeSrcs []string
+
+			for _, src := range tc.srcs {
+				if strings.HasPrefix(src, "/") {
+					absSrcs = append(absSrcs, src)
+				} else {
+					relativeSrcs = append(relativeSrcs, src)
+				}
+			}
+
 			dstDir, dstDirClean := test.CreateTempDir(t, "gzip_extract_"+tc.name, testRootExtracted)
 			t.Cleanup(dstDirClean)
-
+			// Run
+			for _, src := range absSrcs {
+				test.Ok(t, os.RemoveAll(src))
+			}
 			written, err := extract(tc.tgz, tc.archivePath, dstDir)
 			if err != nil {
 				test.Expected(t, err, tc.err)
 				return
 			}
 
+			// Test
 			test.Assert(t, written == tc.written, "case %q: written bytes got %d want %v", tc.name, written, tc.written)
-			test.EqualDirs(t, dstDir, testRootMounted, tc.srcs)
+			for _, src := range absSrcs {
+				test.Exists(t, src)
+			}
+			test.EqualDirs(t, dstDir, testRootMounted, relativeSrcs)
 		})
 	}
 }
@@ -272,11 +349,11 @@ func extract(a *Archive, src string, dst string) (int64, error) {
 
 // Fixtures
 
-func exampleFileTree(t *testing.T, name string) []string {
-	file, fileClean := test.CreateTempFile(t, name, []byte("hello\ndrone!\n"), testRootMounted) // 13 bytes
+func exampleFileTree(t *testing.T, name string, in string) []string {
+	file, fileClean := test.CreateTempFile(t, name, []byte("hello\ndrone!\n"), in) // 13 bytes
 	t.Cleanup(fileClean)
 
-	dir, dirClean := test.CreateTempFilesInDir(t, name, []byte("hello\ngo!\n"), testRootMounted) // 10 bytes
+	dir, dirClean := test.CreateTempFilesInDir(t, name, []byte("hello\ngo!\n"), in) // 10 bytes
 	t.Cleanup(dirClean)
 
 	return []string{file, dir}

--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -85,7 +85,14 @@ func writeToArchive(tw *tar.Writer, root string, skipSymlinks bool, written *int
 			}
 		}
 
-		name, err := relative(root, path)
+		var name string
+
+		if strings.HasPrefix(path, "/") {
+			name, err = filepath.Abs(path)
+		} else {
+			name, err = relative(root, path)
+		}
+
 		if err != nil {
 			return fmt.Errorf("relative name <%s>: <%s>, %w", path, root, err)
 		}
@@ -182,7 +189,7 @@ func (a *Archive) Extract(dst string, r io.Reader) (int64, error) {
 		}
 
 		var target string
-		if dst == h.Name {
+		if dst == h.Name || strings.HasPrefix(h.Name, "/") {
 			target = h.Name
 		} else {
 			name, err := relative(dst, h.Name)

--- a/archive/tar/tar_test.go
+++ b/archive/tar/tar_test.go
@@ -126,7 +126,6 @@ func TestCreate(t *testing.T) {
 
 			_, err = extract(tc.ta, archivePath, extDir)
 			test.Ok(t, err)
-
 			test.EqualDirs(t, extDir, testRootMounted, relativeSrcs)
 
 			for _, src := range absSrcs {
@@ -299,13 +298,10 @@ func TestExtract(t *testing.T) {
 
 			// Test
 			test.Assert(t, written == tc.written, "case %q: written bytes got %d want %v", tc.name, written, tc.written)
-
 			for _, src := range absSrcs {
 				test.Exists(t, src)
 			}
-
 			test.EqualDirs(t, dstDir, testRootMounted, relativeSrcs)
-
 		})
 	}
 }


### PR DESCRIPTION
ALL CREDITS goes to @imranismail
Fixes #130
[#106 comment](https://github.com/meltwater/drone-cache/issues/106#issuecomment-643086789)

### Description
- add absolute path mode to `tar.gz` file by checking for any path prefixed with `/`
- add test in `tar_test.gz` for the absolute path mode.
- since `gzip.go` uses `tar.gz` underneath it, there was no changed made to `gzip.go`
- added test in `gzip_test.go` for the absolute path mode.

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [X] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] Created tests which fail without the change (if possible).
    - [x] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
- [x] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
