### PR TITLE
Add optional param for AWS IAM role assumption

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,11 +17,15 @@ steps:
       - git fetch --tags
 
   - name: configure-buckets
-    image: minio/mc:RELEASE.2018-09-26T00-42-43Z
+    image: minio/mc:RELEASE.2020-10-03T02-54-56Z
     commands:
       - sleep 5
       - mc config host add minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - mc mb --region=eu-west-1 minio/drone-cache-bucket
+      - mc admin user add minio foo barbarbar
+      - "echo '{\"Version\": \"2012-10-17\", \"Statement\": [ { \"Action\": [ \"s3:GetObject\", \"s3:PutObject\", \"s3:DeleteObject\", \"s3:CreateBucket\", \"s3:DeleteBucket\" ], \"Effect\": \"Allow\", \"Resource\": [ \"arn:aws:s3:::s3-round-trip-with-role/*\", \"arn:aws:s3:::s3-round-trip-with-role\" ], \"Sid\": \"\" } ] }' >> /tmp/policy.json"
+      - mc admin policy add minio userpolicy /tmp/policy.json
+      - mc admin policy set minio userpolicy user=foo
 
   - name: build
     image: golang:1.14.4-alpine3.12
@@ -206,7 +210,7 @@ steps:
 
 services:
   - name: minio
-    image: minio/minio:RELEASE.2020-03-05T01-04-19Z
+    image: minio/minio:RELEASE.2020-11-06T23-17-07Z
     commands:
       - minio server /data
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixes [#132](https://github.com/meltwater/drone-cache/issues/132)
 - [#138](https://github.com/meltwater/drone-cache/pull/138) backend/gcs: Fix GCS to pass credentials correctly when `GCS_ENDPOINT` is not set.
 - [#135](https://github.com/meltwater/drone-cache/issues/135) backend/gcs: Fixed parsing of GCS JSON key.
-
+- [#142](https://github.com/meltwater/drone-cache/issues/142) backend/s3: Add option to assume AWS IAM role
 ### Added
 
 - [#102](https://github.com/meltwater/drone-cache/pull/102) Implement option to disable cache rebuild if it already exists in storage.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ GLOBAL OPTIONS:
    --path-style                          AWS path style to use for bucket paths. (true for minio, false for aws) (default: false) [$PLUGIN_PATH_STYLE, $AWS_PLUGIN_PATH_STYLE]
    --acl value                           upload files with acl (private, public-read, ...) (default: "private") [$PLUGIN_ACL, $AWS_ACL]
    --encryption value                    server-side encryption algorithm, defaults to none. (AES256, aws:kms) [$PLUGIN_ENCRYPTION, $AWS_ENCRYPTION]
+   --role-arn value                      AWS IAM role ARN to assume [$PLUGIN_ASSUME_ROLE_ARN, $AWS_ASSUME_ROLE_ARN]
    --gcs.api-key value                   Google service account API key [$PLUGIN_API_KEY, $GCP_API_KEY]
    --gcs.json-key value                  Google service account JSON key [$PLUGIN_JSON_KEY, $GCS_CACHE_JSON_KEY]
    --gcs.acl value                       upload files with acl (private, public-read, ...) (default: "private") [$PLUGIN_GCS_ACL, $GCS_ACL]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   minio:
-    image: minio/minio:RELEASE.2020-03-05T01-04-19Z
+    image: minio/minio:RELEASE.2020-11-06T23-17-07Z
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -25,8 +25,16 @@ services:
     - "10000:10000"
     command: azurite-blob --blobHost 0.0.0.0
   configure-buckets:
-    image: minio/mc:RELEASE.2020-02-20T23-49-54Z
+    image: minio/mc:RELEASE.2020-10-03T02-54-56Z
     entrypoint: sh
     depends_on:
       - minio
-    command: -c "sleep 5 && mc config host add minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    command:
+      - -c
+      - |
+        sleep 2 &&
+        mc config host add minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY &&
+        mc admin user add minio foo barbarbar &&
+        echo '{"Version": "2012-10-17", "Statement": [{"Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:CreateBucket", "s3:DeleteBucket"], "Effect": "Allow", "Resource": ["arn:aws:s3:::s3-round-trip-with-role/*", "arn:aws:s3:::s3-round-trip-with-role"], "Sid": ""}]}' > /tmp/policy.json &&
+        mc admin policy add minio userpolicy /tmp/policy.json &&
+        mc admin policy set minio userpolicy user=foo

--- a/main.go
+++ b/main.go
@@ -363,6 +363,12 @@ func main() {
 			Usage:   "server-side encryption algorithm, defaults to none. (AES256, aws:kms)",
 			EnvVars: []string{"PLUGIN_ENCRYPTION", "AWS_ENCRYPTION"},
 		},
+		&cli.StringFlag{
+			Name:    "role-arn",
+			Usage:   "AWS IAM role ARN to assume",
+			Value:   "",
+			EnvVars: []string{"PLUGIN_ASSUME_ROLE_ARN", "AWS_ASSUME_ROLE_ARN"},
+		},
 
 		// GCS specific Configs flags
 

--- a/storage/backend/s3/config.go
+++ b/storage/backend/s3/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Encryption string // if not "", enables server-side encryption. valid values are: AES256, aws:kms.
 	Endpoint   string
 	Key        string
+	RoleArn    string // if "", do not assume IAM role i.e. use the IAM user.
 
 	// us-east-1
 	// us-west-1


### PR DESCRIPTION
Fixes #142

## Proposed Changes
- add flag to specify role arn
- if role arn is specified, use access keys to assume the role with arn provided

### Description
Allows specifying role ARN which, if specified, is assumed with STS. All S3 operations are executed with this role.

### Checklist

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Ensure your code follows the code style of this project.
- [x] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] Created tests which fail without the change (if possible).
    - [x] All new and existing tests passed.
- [x] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
