### PR TITLE
set goarch for arm64 goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,6 +142,7 @@ dockers:
     skip_push: auto
     dockerfile: Dockerfile
     use: buildx
+    goarch: arm64
     build_flag_templates:
     - "--platform=linux/arm64"
     - "--label=org.label-schema.schema-version=1.0"


### PR DESCRIPTION
## Proposed Changes
<!-- Please briefly list the changes you made here. -->

- set goarch for arm64 goreleaser

### Description

- docker image was published with a amd64 binary because this was not set
