### PR TITLE
[SKIP CI] Wrap `cache_key` in single-quotes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ steps:
     pull: true
     settings:
       restore: true
-      cache_key: {{ .Commit.Branch }}-{{ checksum "go.mod" }} # default if ommitted is {{ .Commit.Branch }}
+      cache_key: '{{ .Commit.Branch }}-{{ checksum "go.mod" }}' # default if ommitted is {{ .Commit.Branch }}
       bucket: drone-cache-bucket
       region: eu-west-1
       mount:
@@ -93,7 +93,7 @@ steps:
         from_secret: aws_secret_access_key
     settings:
       rebuild: true
-      cache_key: {{ .Commit.Branch }}-{{ checksum "go.mod" }} # default if ommitted is {{ .Commit.Branch }}
+      cache_key: '{{ .Commit.Branch }}-{{ checksum "go.mod" }}' # default if ommitted is {{ .Commit.Branch }}
       bucket: drone-cache-bucket
       region: eu-west-1
       mount:


### PR DESCRIPTION
Without forcing the value to be interpreted as a string, the `{` bracket starts a new object block, and gives the following failure from drone:

```
yaml: invalid map key: map[interface {}]interface {}{"checksum \"yarn.lock\"":interface {}(nil)}
```