### PR TITLE
Restore file modification times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#212](https://github.com/meltwater/drone-cache/pull/212) `filesystem` backend now restores files modification time (with sub-second prevision if possible)
 - [#209](https://github.com/meltwater/drone-cache/pull/209) Added double star directory searching in mounts (e.g. `path/**/subdir`)
 - [#198](https://github.com/meltwater/drone-cache/pull/198) Add `hashFiles` template function to generate the SHA256 hash of multiple files
 

--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -72,7 +72,6 @@ func writeToArchive(tw *tar.Writer, root string, skipSymlinks bool, written *int
 		if err != nil {
 			return fmt.Errorf("create header for <%s>, %w", path, err)
 		}
-		h.Format = tar.FormatPAX
 
 		if fi.Mode()&os.ModeSymlink != 0 { // isSymbolic
 			if skipSymlinks {
@@ -91,6 +90,7 @@ func writeToArchive(tw *tar.Writer, root string, skipSymlinks bool, written *int
 		}
 
 		h.Name = name
+		h.Format = tar.FormatPAX
 
 		if err := tw.WriteHeader(h); err != nil {
 			return fmt.Errorf("write header for <%s>, %w", path, err)


### PR DESCRIPTION
Fixes #210

## Proposed Changes
<!-- Please briefly list the changes you made here. -->

- First, archive/tar now uses PAX tar format which allows for sub-second resolutions (https://pkg.go.dev/archive/tar#Format). This only affects rebuild's, so previosly built archive will not be broken. 
- And then extracting files, it sets times if file header container modification time.
- Please not that only files' timestamps are currently restored, not directories'.

### Description

In line with the liked issue, currently restored files (when using filesystem backend) do not preserve original timestamps, which leads to some build systems to rebuild. This PR fixes that.

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](/CODE_OF_CONDUCT.md) document.
- [x] Ensure your code follows the code style of this project.
- [X] Ensure CI and all other PR checks are green
- [x] Add your changes to `Unreleased` section of [CHANGELOG](/CHANGELOG.md).
- [x] Ensure [documentation](/DOCS.md) is up-to-date.
