### PR TITLE
[skip ci] Update CODEOWNERS for 2022 onwards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence, @global-owner1 and @global-owner2
 # will be requested for review when someone opens a pull request.
-*       @limayekaiwalya @seandtaber
+*       @bdebyl @seandtaber
 
 # Order is important; the last matching pattern takes the most precedence.
 # When someone opens a pull request that only modifies JS files, only @js-owner


### PR DESCRIPTION
General update of CODEOWNERS to reflect latest project ownership. No CI validation needed.