### PR TITLE
[skip ci] bump goreleaser and action to attempt to fix releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,9 +37,9 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       -
         name: Run GoReleaser for Release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v3
         with:
-          version: v0.180.3
+          version: v1.11.4
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
No change to source, just trying to fix automation to build the releases correctly due to old issues with `go-ieproxy`